### PR TITLE
Reactive forms module

### DIFF
--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -1,0 +1,4 @@
+// packages/slash/src/forms/index.ts
+export * from "./form.types";
+export * from "./form.helpers";
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // src/index.ts
-export { html, h, render, Repeat, destroyNode } from "./hyper";
+export { html, html as tsx, html as jsx, h, render, Repeat, destroyNode } from "./hyper";
 export { createSignal, effect, computed, memo } from "./signals";
 export * from "./components";
 
@@ -11,6 +11,8 @@ export type {
   Signal, ReadonlySignal, SignalArray, ReadonlySignalArray,
   Renderer
 } from "./types";
+
+export * from "./forms"
 
 
 


### PR DESCRIPTION
# Reactive forms module

All notable changes to this project will be documented in this file.

The format is based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
Release dates use ISO-8601 (YYYY-MM-DD).

---

## [0.3.0] - 2025-09-28

### Added
- **Forms module (`slash/forms`)**
  - New type-safe event model in `form.types.ts`:
    - `FormEvent<TTarget, TEvent>` base type that preserves native API (`e.target.value`, `e.target.checked`, etc.).
    - Merged aliases: `TextFieldEvent`, `CheckboxEvent`, `RadioEvent`, `SelectEvent`, `ButtonEvent`, `FormSubmitEvent`, `FormResetEvent`, `FormInputEvent`, `FormChangeEvent`, `FormFocusInEvent`, `FormFocusOutEvent`, `FormDataEvent`.
    - Element aliases: `TextFieldElement`, `CheckboxElement`, `RadioElement`, `SelectElement`, `ButtonElement`, `FormElement`.
  - Helper utilities in `form.helpers.ts`:
    - Two-way bindings: `textFieldControl`, `checkboxControl`, `radioControl`, `selectControl` (opt‑in `mode` for text fields: `"input" | "change" | "both"`).
    - Value readers: `getText`, `getChecked`, `getSelectValue`.
    - Lightweight, typed **event delegation**: `delegate(root, type, selector, handler)`.
    - Form data helpers: `formToObject(form)`, `onSubmit(cb)`; plus small utilities `onReset`, `onButtonClick`.
  - Barrel export in `slash/forms/index.ts` to simplify imports:  
    ```ts
    import { textFieldControl, FormSubmitEvent } from "slash/forms";
    ```

- **Reactive DOM bindings in `hyper.ts`**
  - Signals bound to **attributes & properties** update the DOM automatically:
    - `value=${signal}` (inputs, textarea, select) keeps UI in sync with state.
    - `checked=${signal}` (checkbox/radio) is fully controlled (also updates `defaultChecked`).
    - `class=${signal | computed}` supports strings, arrays, and object maps reactively.
    - `style=${object | signalOfObject}` merges styles reactively.
  - **Reactive children** now support both text and HTML fragments returned by `computed()`:
    - Strings/numbers become text nodes.
    - `Node`/arrays of `Child` are inserted as-is.
    - `ReadonlySignal<Child>` (including `computed(...)`) is subscribed and swapped in place.

- **List rendering DX**
  - `createSignal<T[]>(...)` returns a `ListSignal<T>` with `.map(renderer)`:
    - Internally wires to `Repeat(...)` with stable keys (prefers `id`/`key`, falls back to identity/primitive strategy).
    - Enables idiomatic syntax:  
      ```ts
      html`<ul>${todos.map(t => html`<li>${t.title}</li>`)}</ul>`
      ```

### Changed
- **Controlled inputs**: improvements in `hyper.ts` for `value`/`checked` ensure the DOM reflects programmatic `signal.set(...)` calls immediately (including `defaultValue`/`defaultChecked` sync and `<select>` option selection).
- **Components helpers**: legacy helpers `modelText`, `modelChecked`, `modelSelect` were **deprecated** in favor of the new form helpers. They remain temporarily for compatibility but will be removed in a future minor release.
- **Types organization**: new `types.ts` and `forms/*.ts` exports to avoid import cycles between `hyper.ts`, `signals.ts`, and components.

### Fixed
- Reactive rendering of repeated static markup (same inner content) no longer collapses siblings. Internals now clone/mount nodes safely (`appendNodeSafe`) to prevent accidental node moves.
- `computed()` returning HTML fragments now updates correctly without leaving orphan nodes.
- Events typing in `hyper.ts` cleaned up; no `any`, unified `parseEventProp` handling tuples `[handler, options?]`.
- `Repeat(...)` keyed-diff stability and movement handling improved for lists where items produce multiple sibling nodes.

### Docs
- Examples updated to show:
  - Text field + validation with `computed()` and CSS modules.
  - Simple todo list using `ListSignal.map(...)` and two-way binding for the input toolbar.

### Deprecations
- `modelText`, `modelChecked`, `modelSelect` (from `components.ts`). Use:
  - `textFieldControl`, `checkboxControl`, `radioControl`, `selectControl` from `slash/forms`.

### Migration Notes
- For two-way text inputs, prefer:
  ```ts
  const name = createSignal("");
  html`<input value=${name} ...${textFieldControl(name, "input")} />`
  ```
- If you previously relied on `onChange`, set `textFieldControl(name, "both")` or attach your own handler.
- For lists previously built with `Repeat(...)`, you can keep using it or migrate to `todos.map(...)` for terser syntax.

---

## [0.2.0] - 2025-09-27

### Added
- Signals core overhaul: dependency tracking with `effect()` and `computed()`; microtask scheduler for batched re-runs.
- `Repeat(listSig, keyOf, renderItem)` keyed list renderer.
- `html`/`h` rendering pipeline (HTM integration) with lifecycle cleanups.

### Fixed
- Multiple rendering issues with document fragments and repeated equal content.

---

## [0.1.0] - 2025-09-26

### Initial release
- Minimal reactive signals (`createSignal`, `effect`, `computed`).
- `html` tag (HTM) and simple DOM renderer.
